### PR TITLE
Default config override

### DIFF
--- a/cloudfront-config.js
+++ b/cloudfront-config.js
@@ -1,7 +1,6 @@
 module.exports = function (config) {
   config.aliases = config.aliases || []
-
-  return {
+  var defaultConfig = {
     DistributionConfig: {
       Enabled: true,
       Aliases: {
@@ -64,4 +63,7 @@ module.exports = function (config) {
       }
     }
   }
+
+  var config = Object.assign({}, defaultConfig.DistributionConfig, config.DistributionConfig);
+  return {DistributionConfig: config};
 }


### PR DESCRIPTION
I was running into a situation where I needed to be able to set up the config a bit differently. What do you think of adding this to allow any field to be optionally set, as per the AWS documentation? 