### PR TITLE
Support for non-IAM certificates.

### DIFF
--- a/cloudfront-config.js
+++ b/cloudfront-config.js
@@ -57,7 +57,7 @@ module.exports = function (config) {
       },
       PriceClass: 'PriceClass_100',
       ViewerCertificate: {
-        CloudFrontDefaultCertificate: !(config.certId && config.acmCertId),
+        CloudFrontDefaultCertificate: !config.certId && !config.acmCertId,
         ACMCertificateArn: config.acmCertId,
         IAMCertificateId: config.certId,
         MinimumProtocolVersion: 'TLSv1',

--- a/cloudfront-config.js
+++ b/cloudfront-config.js
@@ -31,7 +31,7 @@ module.exports = function (config) {
       CacheBehaviors: {
         Quantity: 0
       },
-      DefaultRootObject: '/',
+      DefaultRootObject: config.index,
       Origins: {
         Quantity: 1,
         Items: [

--- a/cloudfront-config.js
+++ b/cloudfront-config.js
@@ -57,7 +57,8 @@ module.exports = function (config) {
       },
       PriceClass: 'PriceClass_100',
       ViewerCertificate: {
-        CloudFrontDefaultCertificate: !config.certId,
+        CloudFrontDefaultCertificate: !(config.certId && config.acmCertId),
+        ACMCertificateArn: config.acmCertId,
         IAMCertificateId: config.certId,
         MinimumProtocolVersion: 'TLSv1',
         SSLSupportMethod: 'sni-only'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "cloudfront-tls",
-  "version": "1.0.0",
+  "name": "@rlyle1179/cloudfront-tls",
+  "version": "1.0.1",
   "description": "Sets up a cloudfront distribution with custom TLS certificates",
   "main": "index.js",
   "scripts": {
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/klaemo/cloudfront-tls"
+    "url": "https://github.com/rlyle/cloudfront-tls"
   },
   "keywords": [
     "cloudfront",
@@ -25,9 +25,9 @@
   "author": "Clemens Stolle <klaemo@fastmail.fm>",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/klaemo/cloudfront-tls/issues"
+    "url": "https://github.com/rlyle/cloudfront-tls/issues"
   },
-  "homepage": "https://github.com/klaemo/cloudfront-tls",
+  "homepage": "https://github.com/rlyle/cloudfront-tls",
   "dependencies": {
     "async": "^0.9.0",
     "aws-sdk": "^2.1.4",


### PR DESCRIPTION
Our certificate is managed by AWS, so I think we need to use the ACMCertificateArn instead of the IAMCertificateId.